### PR TITLE
Corrected behavior for opening the History page

### DIFF
--- a/app.min.js
+++ b/app.min.js
@@ -38446,7 +38446,7 @@
   function prepared(action, name) {
     if (name.indexOf(action) >= 0) {
       var comp = Lampa.Activity.active().component;
-      if (name.indexOf(comp) >= 0) Activity$1.replace();else return true;
+      if (name.indexOf(comp) >= 0 && (!type || comp.type == type)) Activity$1.replace();else return true;
     }
   }
 
@@ -38528,7 +38528,7 @@
 
       if (action == 'history') {
         ParentalControl.personal('bookmarks', function () {
-          if (prepared('favorite', ['favorite'])) {
+          if (prepared('favorite', ['favorite'], 'history')) {
             Activity$1.push({
               url: '',
               title: Lang.translate('title_history'),


### PR DESCRIPTION
Исправление для открытия страницы истории просмотра с другой Favorite страницы (Закладки, Нравится, Позже и тд). 
Проблема заключается в том, что и для истории, и для закладок используется компонент с одинаковым именем, но с разным типом, что сейчас не учитывается