### PR TITLE
Fixed issue with decode from Base64

### DIFF
--- a/app.min.js
+++ b/app.min.js
@@ -2740,6 +2740,7 @@
       var i = 0;
       var c = 0;
       var c2 = 0;
+      var c3 = 0;
 
       while (i < utftext.length) {
         c = utftext.charCodeAt(i);


### PR DESCRIPTION
В функции _utf8_decode используется не объявленная переменная c3
![image](https://github.com/user-attachments/assets/df643bc5-0293-42fb-88ef-ff6b2432689b)
