### PR TITLE
fix: initialize _collection in SpatialNavigator constructor

### DIFF
--- a/vender/navigator/navigator.js
+++ b/vender/navigator/navigator.js
@@ -40,6 +40,7 @@
 var SpatialNavigator = function () {
   this._focus = null;
   this._previous = null;
+  this._collection = [];
 
   //this.setCollection(collection);
 


### PR DESCRIPTION
I've initialized the _collection array in the SpatialNavigator constructor. Previously, this property was not set until setCollection was called, which could lead to runtime errors if add or multiAdd were invoked on the navigator instance before it was explicitly set. This ensures the spatial navigator is properly prepared upon initialization.